### PR TITLE
MOSIP-21476

### DIFF
--- a/kernel/kernel-auth-adapter/pom.xml
+++ b/kernel/kernel-auth-adapter/pom.xml
@@ -129,6 +129,16 @@
 			<artifactId>kernel-core</artifactId>
 			<version>1.2.0.1-SNAPSHOT</version>
 			<scope>provided</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.logging.log4j</groupId>
+					<artifactId>log4j-to-slf4j</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.logging.log4j</groupId>
+					<artifactId>log4j-api</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>io.mosip.kernel</groupId>


### PR DESCRIPTION
We are facing below error in admin-service during xlsx file upload:
NoSuchMethodError: 'org.apache.logging.log4j.LogBuilder org.apache.logging.log4j.Logger.atDebug()'\n\tat org.apache.poi.openxml4j.opc.PackageRelationshipCollection.parseRelationshipsPart(PackageRelationshipCollection.java:309)

As 2 different versions of the log4j library were present in the classpath, excluded the one part of kernel-core, but log4j is also part of auth-adapter, hence excluding the same in this PR