### PR TITLE
[MOSIP-43615] [MOSIP-43648] [MOSIP-43434] added lifecycle, graceperio…

### DIFF
--- a/helm/authmanager/templates/deployment.yaml
+++ b/helm/authmanager/templates/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       {{- if .Values.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
       {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds | default 60 }}
       {{- if .Values.affinity }}
       affinity: {{- include "common.tplvalues.render" ( dict "value" .Values.affinity "context" $) | nindent 8 }}
       {{- else }}

--- a/helm/authmanager/values.yaml
+++ b/helm/authmanager/values.yaml
@@ -126,16 +126,16 @@ resources:
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   limits:
-    cpu: 500m
-    memory: 2250Mi
+    cpu: 1000m
+    memory: 5000Mi
   requests:
-    cpu: 100m
+    cpu: 300m
     memory: 1500Mi
 
 additionalResources:
   ## Specify any JAVA_OPTS string here. These typically will be specified in conjunction with above resources
   ## Example: java_opts: "-Xms500M -Xmx500M"
-  javaOpts: "-Xms1500M -Xmx1500M"
+  javaOpts: "-Xms4100M -Xmx4100M"
 
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
 ## Clamav container already runs as 'mosip' user, so we may not need to enable this
@@ -216,7 +216,16 @@ podAnnotations: {}
 
 ## lifecycleHooks for the  container to automate configuration before or after startup.
 ##
-lifecycleHooks: {}
+lifecycleHooks:
+  preStop:
+    exec:
+      command:
+        - sh
+        - -c
+        - sleep 30
+
+## Termination grace perios : the maximum amount of time (in seconds) Kubernetes will wait for a container to gracefully shut down
+terminationGracePeriodSeconds: 60
 
 ## Custom Liveness probes for
 ##
@@ -345,8 +354,8 @@ volumePermissions:
   enabled: false
   image:
     registry: docker.io
-    repository: bitnami/bitnami-shell
-    tag: "10"
+    repository: mosipid/os-shell
+    tag: "12-debian-12-r46"
     pullPolicy: Always
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/kernel/kernel-auth-service/pom.xml
+++ b/kernel/kernel-auth-service/pom.xml
@@ -36,7 +36,7 @@
 		<maven.gpg.plugin.version>3.2.3</maven.gpg.plugin.version>
 		<git.commit.id.plugin.version>3.0.1</git.commit.id.plugin.version>
 		<maven.surefire.plugin.version>3.1.2</maven.surefire.plugin.version>
-		<spring.boot.maven.plugin.version>3.2.0</spring.boot.maven.plugin.version>
+		<spring.boot.maven.plugin.version>3.2.3</spring.boot.maven.plugin.version>
 
 		<!-- Mosip -->
 		<kernel.bom.version>1.2.1-SNAPSHOT</kernel.bom.version>


### PR DESCRIPTION
…d and updated bitnami depricated image, resources, probes and .gitignore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased resource allocation: CPU limits now 1000m (from 500m), memory limits now 5000Mi (from 2250Mi), and Java heap increased to 4100M.
  * Enhanced graceful shutdown: Added 60-second termination grace period with preStop lifecycle hook.
  * Updated container base image and Spring Boot Maven plugin to latest patch version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->